### PR TITLE
fix: support ESLint ^7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint"
   ],
   "peerDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": "^6.0.0 || ^7.0.0"
   },
   "author": "Dominic Buetow",
   "license": "MIT",


### PR DESCRIPTION
Already works great with ESLint ^7.0.0, just need to expand peerDependencies so that npm doesn't error when installing.